### PR TITLE
Add sample Flutter tools app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# KiddoWorks Sample Tools App
+
+This repository contains a simple Flutter project demonstrating the basic concept described in the original `readMe.md`. The app provides three playful tools for children:
+
+- **Calculator** – perform simple arithmetic.
+- **Drawing Pad** – draw on the screen and clear the canvas.
+- **Clock** – view the current time updated every second.
+
+## Getting Started
+
+1. Install [Flutter](https://flutter.dev/) on your machine.
+2. Run `flutter pub get` to fetch dependencies.
+3. Launch the app using `flutter run`.
+
+This sample is intentionally minimal but can be expanded with additional tools, animations and sound effects as described in `readMe.md`.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'pages/home_page.dart';
+
+void main() {
+  runApp(const KiddoApp());
+}
+
+class KiddoApp extends StatelessWidget {
+  const KiddoApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Kiddo Works',
+      theme: ThemeData(
+        primarySwatch: Colors.orange,
+      ),
+      home: const HomePage(),
+    );
+  }
+}

--- a/lib/pages/calculator_page.dart
+++ b/lib/pages/calculator_page.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+
+class CalculatorPage extends StatefulWidget {
+  const CalculatorPage({super.key});
+
+  @override
+  State<CalculatorPage> createState() => _CalculatorPageState();
+}
+
+class _CalculatorPageState extends State<CalculatorPage> {
+  final TextEditingController _aController = TextEditingController();
+  final TextEditingController _bController = TextEditingController();
+  String _operation = '+';
+  String _result = '';
+
+  void _calculate() {
+    final a = double.tryParse(_aController.text) ?? 0;
+    final b = double.tryParse(_bController.text) ?? 0;
+    double value;
+    switch (_operation) {
+      case '+':
+        value = a + b;
+        break;
+      case '-':
+        value = a - b;
+        break;
+      case '×':
+        value = a * b;
+        break;
+      case '÷':
+        value = b != 0 ? a / b : double.nan;
+        break;
+      default:
+        value = 0;
+    }
+    setState(() {
+      _result = value.toStringAsFixed(2);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Calculator')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: _aController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: 'First number'),
+            ),
+            TextField(
+              controller: _bController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: 'Second number'),
+            ),
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                _buildOperationButton('+'),
+                _buildOperationButton('-'),
+                _buildOperationButton('×'),
+                _buildOperationButton('÷'),
+              ],
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _calculate,
+              child: const Text('Calculate'),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Result: $_result',
+              style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildOperationButton(String op) {
+    return ElevatedButton(
+      onPressed: () {
+        setState(() {
+          _operation = op;
+        });
+      },
+      child: Text(op),
+    );
+  }
+}

--- a/lib/pages/clock_page.dart
+++ b/lib/pages/clock_page.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+class ClockPage extends StatefulWidget {
+  const ClockPage({super.key});
+
+  @override
+  State<ClockPage> createState() => _ClockPageState();
+}
+
+class _ClockPageState extends State<ClockPage> {
+  late Timer _timer;
+  late DateTime _now;
+
+  @override
+  void initState() {
+    super.initState();
+    _now = DateTime.now();
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      setState(() {
+        _now = DateTime.now();
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Clock')),
+      body: Center(
+        child: Text(
+          _formatTime(_now),
+          style: const TextStyle(fontSize: 48, fontWeight: FontWeight.bold),
+        ),
+      ),
+    );
+  }
+
+  String _formatTime(DateTime time) {
+    final hours = time.hour.toString().padLeft(2, '0');
+    final minutes = time.minute.toString().padLeft(2, '0');
+    final seconds = time.second.toString().padLeft(2, '0');
+    return '$hours:$minutes:$seconds';
+  }
+}

--- a/lib/pages/drawing_page.dart
+++ b/lib/pages/drawing_page.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+class DrawingPage extends StatefulWidget {
+  const DrawingPage({super.key});
+
+  @override
+  State<DrawingPage> createState() => _DrawingPageState();
+}
+
+class _DrawingPageState extends State<DrawingPage> {
+  final List<Offset?> _points = [];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Drawing Pad')),
+      body: GestureDetector(
+        onPanUpdate: (details) {
+          setState(() {
+            RenderBox? referenceBox = context.findRenderObject() as RenderBox?;
+            final point = referenceBox?.globalToLocal(details.globalPosition);
+            _points.add(point);
+          });
+        },
+        onPanEnd: (_) => _points.add(null),
+        child: CustomPaint(
+          painter: _DrawingPainter(points: _points),
+          size: Size.infinite,
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          setState(() {
+            _points.clear();
+          });
+        },
+        child: const Icon(Icons.clear),
+      ),
+    );
+  }
+}
+
+class _DrawingPainter extends CustomPainter {
+  final List<Offset?> points;
+
+  _DrawingPainter({required this.points});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.blue
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = 4.0;
+
+    for (int i = 0; i < points.length - 1; i++) {
+      if (points[i] != null && points[i + 1] != null) {
+        canvas.drawLine(points[i]!, points[i + 1]!, paint);
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
+}

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'calculator_page.dart';
+import 'drawing_page.dart';
+import 'clock_page.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Kiddo Works'),
+      ),
+      body: GridView.count(
+        crossAxisCount: 2,
+        padding: const EdgeInsets.all(16),
+        mainAxisSpacing: 16,
+        crossAxisSpacing: 16,
+        children: [
+          _ToolButton(
+            icon: Icons.calculate,
+            label: 'Calculator',
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const CalculatorPage()),
+              );
+            },
+          ),
+          _ToolButton(
+            icon: Icons.brush,
+            label: 'Drawing Pad',
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const DrawingPage()),
+              );
+            },
+          ),
+          _ToolButton(
+            icon: Icons.access_time,
+            label: 'Clock',
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const ClockPage()),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ToolButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  const _ToolButton({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Card(
+        color: Colors.orangeAccent,
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 64, color: Colors.white),
+              const SizedBox(height: 8),
+              Text(
+                label,
+                style: const TextStyle(fontSize: 18, color: Colors.white),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,18 @@
+name: kiddoworks
+description: A sample tools app for kids built with Flutter.
+version: 1.0.0
+
+environment:
+  sdk: '>=2.18.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- create sample Flutter project skeleton
- implement calculator, drawing pad, and clock pages
- document how to run the sample app

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6870ce3196a0832b9d3d2f4103b0e93f